### PR TITLE
fixed output file name for linux build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 *.js
 *.vsix
+.vs/

--- a/Tasks/UnityBuild/UnityBuildV3/unity-build-script.helper.ts
+++ b/Tasks/UnityBuild/UnityBuildV3/unity-build-script.helper.ts
@@ -121,7 +121,7 @@ export class UnityBuildScriptHelper {
                     case BuildTarget.Switch:
                     case BuildTarget.NoTarget:
                     default:
-                        return string.Empty;
+                        return outputFileName;
                 }
             }
         }`;


### PR DESCRIPTION
When building for Linux64 target, the file name is empty and build fails. This PR fixes the problem for Linux64 and all other builds.