### PR TITLE
Prevent hanging builds

### DIFF
--- a/Tasks/UnityBuild/UnityBuildV3/unity-build.ts
+++ b/Tasks/UnityBuild/UnityBuildV3/unity-build.ts
@@ -87,10 +87,11 @@ async function run() {
 
             // Tell Unity which method to execute for build.
             unityCmd.arg('-executeMethod').arg(isDefault ? 'AzureDevOps.PerformBuild' : tl.getInput('scriptExecuteMethod')!);
-        } else {
-            // Must be build script type "existing".
+        } else if (buildScriptType === 'existing') {
             // If the user already has an existing build script we only need the method to execute.
-            unityCmd.arg('-executeMethod').arg(tl.getInput('scriptExecuteMethod')!);
+            unityCmd.arg('-executeMethod').arg(tl.getInput('scriptExecuteMethod')!).arg('-quit');
+        } else {
+            throw `Unsupported build script type ${buildScriptType}`
         }
 
         const result = await UnityToolRunner.run(unityCmd, logFilePath);


### PR DESCRIPTION
Should fix https://github.com/Dinomite-Studios/unity-azure-pipelines-tasks/issues/137 and https://github.com/Dinomite-Studios/unity-azure-pipelines-tasks/issues/129 for Build Task V3.

Unsure if there are any implications if the existing build script already quits Unity on its own by calling `Application.Quit()`?