### PR TITLE
Add custom Unity version parameter to all tasks

### DIFF
--- a/Tasks/UnityActivateLicense/UnityActivateLicenseV1/task.json
+++ b/Tasks/UnityActivateLicense/UnityActivateLicenseV1/task.json
@@ -70,6 +70,14 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "(Optional) Enter the directory path to the Unity project. If no value is entered, the root of the repository will be used."
+    },
+    {
+      "name": "unityVersion",
+      "type": "string",
+      "label": "Unity version",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "(Optional) Enter the custom version of Unity. If no value is entered, it will be resolved automatically."
     }
   ],
   "outputVariables": [

--- a/Tasks/UnityActivateLicense/UnityActivateLicenseV1/unity-activate-license.ts
+++ b/Tasks/UnityActivateLicense/UnityActivateLicenseV1/unity-activate-license.ts
@@ -17,6 +17,7 @@ const unityEditorsPathModeInputVariableName = 'unityEditorsPathMode';
 const customUnityEditorsPathInputVariableName = 'customUnityEditorsPath';
 const localPathInputVariableName = 'Build.Repository.LocalPath';
 const unityProjectPathInputVariableName = 'unityProjectPath';
+const unityVersionInputVariableName = 'unityVersion';
 
 /**
  * Main task runner. Executes the task and sets the result status for the task.
@@ -28,7 +29,7 @@ async function run() {
         const password = tl.getInput(passwordInputVariableName, true)!;
         const serial = tl.getInput(serialInputVariableName, true)!;
         const projectPath = tl.getPathInput(unityProjectPathInputVariableName) || '';
-        const unityVersion = getUnityEditorVersion();
+        const unityVersion = tl.getInput(unityVersionInputVariableName) || getUnityEditorVersion();
         const unityEditorsPath = UnityPathTools.getUnityEditorsPath(
             tl.getInput(unityEditorsPathModeInputVariableName, true)!,
             tl.getInput(customUnityEditorsPathInputVariableName));

--- a/Tasks/UnityBuild/UnityBuildV3/task.json
+++ b/Tasks/UnityBuild/UnityBuildV3/task.json
@@ -77,6 +77,14 @@
       "helpMarkDown": "(Optional) Enter the directory path to the Unity project. If no value is entered, the root of the repository will be used."
     },
     {
+      "name": "unityVersion",
+      "type": "string",
+      "label": "Unity version",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "(Optional) Enter the custom version of Unity. If no value is entered, it will be resolved automatically."
+    },
+    {
       "name": "buildScriptType",
       "type": "radio",
       "label": "Build script type",

--- a/Tasks/UnityBuild/UnityBuildV3/unity-build.ts
+++ b/Tasks/UnityBuild/UnityBuildV3/unity-build.ts
@@ -16,6 +16,7 @@ const outputFileNameInputVariableName = 'outputFileName';
 const buildTargetInputVariableName = 'buildTarget';
 const outputPathInputVariableName = 'outputPath';
 const unityProjectPathInputVariableName = 'unityProjectPath';
+const unityVersionInputVariableName = 'unityVersion';
 const unityEditorsPathModeInputVariableName = 'unityEditorsPathMode';
 const customUnityEditorsPathInputVariableName = 'customUnityEditorsPath';
 const localPathInputVariableName = 'Build.Repository.LocalPath';
@@ -37,7 +38,7 @@ async function run() {
         const unityEditorsPath = UnityPathTools.getUnityEditorsPath(
             tl.getInput(unityEditorsPathModeInputVariableName, true)!,
             tl.getInput(customUnityEditorsPathInputVariableName));
-        const unityVersion = getUnityEditorVersion();
+        const unityVersion = tl.getInput(unityVersionInputVariableName) || getUnityEditorVersion();
         const unityExecutablePath = UnityPathTools.getUnityExecutableFullPath(unityEditorsPath, unityVersion.info!);
         const cleanBuild = tl.getVariable(cleanBuildInputVariableName);
         const repositoryLocalPath = tl.getVariable(localPathInputVariableName)!;

--- a/Tasks/UnityCMD/UnityCMDV1/task.json
+++ b/Tasks/UnityCMD/UnityCMDV1/task.json
@@ -48,6 +48,14 @@
       "helpMarkDown": "(Optional) Enter the directory path to the Unity project. If no value is entered, the root of the repository will be used."
     },
     {
+      "name": "unityVersion",
+      "type": "string",
+      "label": "Unity version",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "(Optional) Enter the custom version of Unity. If no value is entered, it will be resolved automatically."
+    },
+    {
       "name": "cmdArgs",
       "type": "string",
       "label": "Command line arguments",

--- a/Tasks/UnityCMD/UnityCMDV1/unity-cmd.ts
+++ b/Tasks/UnityCMD/UnityCMDV1/unity-cmd.ts
@@ -11,6 +11,7 @@ tl.setResourcePath(path.join(__dirname, 'task.json'));
 
 // Input variables.
 const unityProjectPathInputVariableName = 'unityProjectPath';
+const unityVersionInputVariableName = 'unityVersion';
 const unityEditorsPathModeInputVariableName = 'unityEditorsPathMode';
 const customUnityEditorsPathInputVariableName = 'customUnityEditorsPath';
 const cmdArgsInputVariableName = 'cmdArgs';
@@ -29,7 +30,7 @@ async function run() {
         const unityEditorsPath = UnityPathTools.getUnityEditorsPath(
             tl.getInput(unityEditorsPathModeInputVariableName, true)!,
             tl.getInput(customUnityEditorsPathInputVariableName));
-        const unityVersion = getUnityEditorVersion();
+        const unityVersion = tl.getInput(unityVersionInputVariableName) || getUnityEditorVersion();
         const unityExecutablePath = UnityPathTools.getUnityExecutableFullPath(unityEditorsPath, unityVersion.info!);
         const repositoryLocalPath = tl.getVariable(localPathInputVariableName)!;
         const logFilesDirectory = path.join(repositoryLocalPath!, 'Logs');

--- a/Tasks/UnityTest/UnityTestV1/task.json
+++ b/Tasks/UnityTest/UnityTestV1/task.json
@@ -66,6 +66,14 @@
       "helpMarkDown": "(Optional) Enter the directory path to the Unity project. If no value is entered, the root of the repository will be used."
     },
     {
+      "name": "unityVersion",
+      "type": "string",
+      "label": "Unity version",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "(Optional) Enter the custom version of Unity. If no value is entered, it will be resolved automatically."
+    },
+    {
       "name": "failOnTestFail",
       "type": "boolean",
       "label": "Fails when at least one test has failed",

--- a/Tasks/UnityTest/UnityTestV1/unity-test.ts
+++ b/Tasks/UnityTest/UnityTestV1/unity-test.ts
@@ -16,6 +16,7 @@ const testModeInputVariableName = 'testMode';
 const unityEditorsPathModeInputVariableName = 'unityEditorsPathMode';
 const customUnityEditorsPathInputVariableName = 'customUnityEditorsPath';
 const unityProjectPathInputVariableName = 'unityProjectPath';
+const unityVersionInputVariableName = 'unityVersion';
 const testCategoryInputVariableName = 'testCategory';
 const testFilterInputVariableName = 'testFilter';
 const failOnTestFailInputVariableName = 'failOnTestFail';
@@ -53,7 +54,7 @@ async function run() {
         const unityEditorsPath = UnityPathTools.getUnityEditorsPath(
             tl.getInput(unityEditorsPathModeInputVariableName, true)!,
             tl.getInput(customUnityEditorsPathInputVariableName));
-        const unityVersion = getUnityEditorVersion();
+        const unityVersion = tl.getInput(unityVersionInputVariableName) || getUnityEditorVersion();
         const unityExecutablePath = UnityPathTools.getUnityExecutableFullPath(unityEditorsPath, unityVersion.info!);
         const cleanBuild = tl.getVariable(cleanBuildInputVariableName);
         const batchMode = tl.getBoolInput(batchModeInputVariableName);


### PR DESCRIPTION
@FejZa Right now it is not possible to open Unity with a version other than the one defined in the ProjectVersion.txt file that is being solved automatically.

We have a use case in which we want to open Unity in a higher version for cases such as checking the compatibility of the code in other versions of Unity.

In this PR I add an optional parameter to all the tasks in which it is possible to define that parameter, if it is not defined, it will work as until now.