### PR TITLE
Fix unity activate license tasks to respect project path

### DIFF
--- a/Tasks/UnityActivateLicense/UnityActivateLicenseV1/CHANGELOG.md
+++ b/Tasks/UnityActivateLicense/UnityActivateLicenseV1/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1]
+
+### Fixed
+
+- Respect `unityProjectPath` in unity activate license tasks [GitHub Issue](https://github.com/Dinomite-Studios/unity-azure-pipelines-tasks/issues/225)
+
 ## [1.2.0]
 
 ### Added

--- a/Tasks/UnityActivateLicense/UnityActivateLicenseV1/post-unity-activate-license.ts
+++ b/Tasks/UnityActivateLicense/UnityActivateLicenseV1/post-unity-activate-license.ts
@@ -11,6 +11,7 @@ import {
     localPathInputVariableName,
     passwordInputVariableName,
     unityEditorsPathModeInputVariableName,
+    unityProjectPathInputVariable,
     usernameInputVariableName,
     versionInputVariableName,
     versionSelectionModeVariableName
@@ -37,6 +38,7 @@ function run() {
         const unityEditorsPath = UnityPathTools.getUnityEditorsPath(
             tl.getInput(unityEditorsPathModeInputVariableName, true)!,
             tl.getInput(customUnityEditorsPathInputVariableName));
+        const unityProjectPath = tl.getPathInput(unityProjectPathInputVariable) || '';
 
         var unityVersion: UnityVersionInfoResult;
         if (versionSelectionMode === 'specify') {
@@ -67,6 +69,7 @@ function run() {
                 .arg('-batchmode')
                 .arg('-quit')
                 .arg('-nographics')
+                .arg('-projectPath').arg(unityProjectPath)
                 .arg('-username').arg(username)
                 .arg('-password').arg(password)
                 .arg('-returnlicense')

--- a/Tasks/UnityActivateLicense/UnityActivateLicenseV1/post-unity-activate-license.ts
+++ b/Tasks/UnityActivateLicense/UnityActivateLicenseV1/post-unity-activate-license.ts
@@ -11,7 +11,7 @@ import {
     localPathInputVariableName,
     passwordInputVariableName,
     unityEditorsPathModeInputVariableName,
-    unityProjectPathInputVariable,
+    unityProjectPathInputVariableName,
     usernameInputVariableName,
     versionInputVariableName,
     versionSelectionModeVariableName
@@ -38,7 +38,7 @@ function run() {
         const unityEditorsPath = UnityPathTools.getUnityEditorsPath(
             tl.getInput(unityEditorsPathModeInputVariableName, true)!,
             tl.getInput(customUnityEditorsPathInputVariableName));
-        const unityProjectPath = tl.getPathInput(unityProjectPathInputVariable) || '';
+        const unityProjectPath = tl.getPathInput(unityProjectPathInputVariableName) || '';
 
         var unityVersion: UnityVersionInfoResult;
         if (versionSelectionMode === 'specify') {

--- a/Tasks/UnityActivateLicense/UnityActivateLicenseV1/unity-activate-license.ts
+++ b/Tasks/UnityActivateLicense/UnityActivateLicenseV1/unity-activate-license.ts
@@ -13,7 +13,7 @@ export const passwordInputVariableName = 'password';
 export const versionInputVariableName = 'version';
 export const unityEditorsPathModeInputVariableName = 'unityEditorsPathMode';
 export const customUnityEditorsPathInputVariableName = 'customUnityEditorsPath';
-export const unityProjectPathInputVariable = "unityProjectPath";
+export const unityProjectPathInputVariableName = "unityProjectPath";
 export const localPathInputVariableName = 'Build.Repository.LocalPath';
 export const versionSelectionModeVariableName = "versionSelectionMode";
 const serialInputVariableName = 'serial';
@@ -31,7 +31,7 @@ function run() {
         const unityEditorsPath = UnityPathTools.getUnityEditorsPath(
             tl.getInput(unityEditorsPathModeInputVariableName, true)!,
             tl.getInput(customUnityEditorsPathInputVariableName));
-        const unityProjectPath = tl.getPathInput(unityProjectPathInputVariable) || '';
+        const unityProjectPath = tl.getPathInput(unityProjectPathInputVariableName) || '';
 
         var unityVersion: UnityVersionInfoResult;
         if (versionSelectionMode === 'specify') {

--- a/Tasks/UnityActivateLicense/UnityActivateLicenseV1/unity-activate-license.ts
+++ b/Tasks/UnityActivateLicense/UnityActivateLicenseV1/unity-activate-license.ts
@@ -13,6 +13,7 @@ export const passwordInputVariableName = 'password';
 export const versionInputVariableName = 'version';
 export const unityEditorsPathModeInputVariableName = 'unityEditorsPathMode';
 export const customUnityEditorsPathInputVariableName = 'customUnityEditorsPath';
+export const unityProjectPathInputVariable = "unityProjectPath";
 export const localPathInputVariableName = 'Build.Repository.LocalPath';
 export const versionSelectionModeVariableName = "versionSelectionMode";
 const serialInputVariableName = 'serial';
@@ -30,6 +31,7 @@ function run() {
         const unityEditorsPath = UnityPathTools.getUnityEditorsPath(
             tl.getInput(unityEditorsPathModeInputVariableName, true)!,
             tl.getInput(customUnityEditorsPathInputVariableName));
+        const unityProjectPath = tl.getPathInput(unityProjectPathInputVariable) || '';
 
         var unityVersion: UnityVersionInfoResult;
         if (versionSelectionMode === 'specify') {
@@ -59,6 +61,7 @@ function run() {
             .arg('-batchmode')
             .arg('-quit')
             .arg('-nographics')
+            .arg('-projectPath').arg(unityProjectPath)
             .arg('-username').arg(username)
             .arg('-password').arg(password)
             .arg('-serial ').arg(serial)


### PR DESCRIPTION
Currently unity-activate-license and post-unity-activate-license do not respect the unityProjectPath input parameter. This is necessary if a repository holds multiple projects.

[GitHub Issue](https://github.com/Dinomite-Studios/unity-azure-pipelines-tasks/issues/225)