### PR TITLE
Mark Unity version as required

### DIFF
--- a/Tasks/UnityTest/UnityTestV1/task.json
+++ b/Tasks/UnityTest/UnityTestV1/task.json
@@ -70,7 +70,7 @@
       "type": "string",
       "label": "Unity version",
       "defaultValue": "",
-      "required": false,
+      "required": true,
       "helpMarkDown": "(Optional) Enter the custom version of Unity. If no value is entered, it will be resolved automatically."
     },
     {


### PR DESCRIPTION
To avoid `Path` [issues](https://github.com/Dinomite-Studios/unity-azure-pipelines-tasks/issues/219), the unity version should be specified and marked as a required input.