### PR TITLE
Fix Unity Test Task so it doesn't rely on specifying a UnityVersion

### DIFF
--- a/Tasks/UnityTest/UnityTestV1/unity-test.ts
+++ b/Tasks/UnityTest/UnityTestV1/unity-test.ts
@@ -55,7 +55,8 @@ async function run() {
         const unityEditorsPath = UnityPathTools.getUnityEditorsPath(
             tl.getInput(unityEditorsPathModeInputVariableName, true)!,
             tl.getInput(customUnityEditorsPathInputVariableName));
-        const unityVersion = { info: { version: tl.getInput(unityVersionInputVariableName) } } as UnityVersionInfoResult || getUnityEditorVersion();
+        const unityVersionInput = tl.getInput(unityVersionInputVariableName);
+        const unityVersion = unityVersionInput ? { info: { version: unityVersionInput } } as UnityVersionInfoResult : getUnityEditorVersion();
         const unityExecutablePath = UnityPathTools.getUnityExecutableFullPath(unityEditorsPath, unityVersion.info!);
         const cleanBuild = tl.getVariable(cleanBuildInputVariableName);
         const batchMode = tl.getBoolInput(batchModeInputVariableName);


### PR DESCRIPTION
I've been encountering a problem where my Unity Test task always gets this error which only goes away if I specify a UnityVersion. 
![image](https://github.com/Dinomite-Studios/unity-azure-pipelines-tasks/assets/10147303/953bfdfd-0ed5-4466-99da-94b573d3094b)

I discovered in PR #206 that there was a problem which was created in how tasks were getting the `UnityVersion` which would result in the UnityVersion having a non-null `UnityVersionInfoResult` object with an empty string for the `UnityVersion`. 

Upon investigation it looks like this issue had already been resolved for some other tasks like the Build task but not for this Unity Test task.

My hope is that this will solve the root problem of issue #219 and address the looming problem noted in PR #206 as it relates to `UnityTest` task