### PR TITLE
Adjust log output variable to point to log file

### DIFF
--- a/Tasks/UnityActivateLicense/UnityActivateLicenseV1/CHANGELOG.md
+++ b/Tasks/UnityActivateLicense/UnityActivateLicenseV1/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4]
+
+### Changed
+
+- The output variable `editorLogFilePath` now points directly to the genereated lot file instead of the folder containing it. This is to avoid uploading log files from previous runs if there happen to be multiple log files in the log directory
+
 ## [1.2.3]
 
 ### Fixed

--- a/Tasks/UnityActivateLicense/UnityActivateLicenseV1/package.json
+++ b/Tasks/UnityActivateLicense/UnityActivateLicenseV1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dinomite-studios/unity-activate-license-task",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Azure Pipelines task to activate a Unity Pro license prior to building a project.",
   "main": "unity-activate-license.js",
   "scripts": {

--- a/Tasks/UnityActivateLicense/UnityActivateLicenseV1/post-unity-activate-license.ts
+++ b/Tasks/UnityActivateLicense/UnityActivateLicenseV1/post-unity-activate-license.ts
@@ -8,7 +8,7 @@ import {
 } from '@dinomite-studios/unity-azure-pipelines-tasks-lib';
 import {
     customUnityEditorsPathInputVariableName,
-    tempDirectoryInputVariableName,
+    editorLogFilePathOutputVariableName,
     passwordInputVariableName,
     unityEditorsPathModeInputVariableName,
     usernameInputVariableName,
@@ -49,12 +49,12 @@ function run() {
             unityVersion = getUnityEditorVersion();
         }
 
-        const unityExecutablePath = UnityPathTools.getUnityExecutableFullPath(unityEditorsPath, unityVersion.info!);
-        const logFilesDirectory = path.join(tl.getVariable(tempDirectoryInputVariableName)!, 'Logs');
-        const logFilePath = path.join(logFilesDirectory, `UnityReturnLicenseLog_${Utilities.getLogFileNameTimeStamp()}.log`);
-
         // Set output variable values.
-        tl.setVariable('logsOutputPath', logFilesDirectory);
+        const logFilesDirectory = path.join(tl.getVariable('Agent.TempDirectory')!, 'Logs');
+        const logFilePath = path.join(logFilesDirectory, `UnityReturnLicenseLog_${Utilities.getLogFileNameTimeStamp()}.log`);
+        tl.setVariable(editorLogFilePathOutputVariableName, logFilePath);
+
+        const unityExecutablePath = UnityPathTools.getUnityExecutableFullPath(unityEditorsPath, unityVersion.info!);
 
         // Execute Unity command line.
         if (deactivateSeatOnComplete) {

--- a/Tasks/UnityActivateLicense/UnityActivateLicenseV1/task.json
+++ b/Tasks/UnityActivateLicense/UnityActivateLicenseV1/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 2,
-    "Patch": 3
+    "Patch": 4
   },
   "releaseNotes": "[Full Changelog](https://github.com/Dinomite-Studios/unity-azure-pipelines-tasks/blob/master/Tasks/UnityActivateLicense/UnityActivateLicenseV1/CHANGELOG.md)",
   "minimumAgentVersion": "2.144.0",
@@ -111,8 +111,8 @@
   ],
   "outputVariables": [
     {
-      "name": "logsOutputPath",
-      "description": "Path to the Unity editor log files generated."
+      "name": "editorLogFilePath",
+      "description": "Specifies the location of the editor log file generated."
     }
   ],
   "execution": {

--- a/Tasks/UnityActivateLicense/UnityActivateLicenseV1/unity-activate-license.ts
+++ b/Tasks/UnityActivateLicense/UnityActivateLicenseV1/unity-activate-license.ts
@@ -15,7 +15,9 @@ export const versionSelectionModeVariableName = "versionSelectionMode";
 export const versionInputVariableName = 'version';
 export const unityEditorsPathModeInputVariableName = 'unityEditorsLocation';
 export const customUnityEditorsPathInputVariableName = 'customUnityEditorsLocation';
-export const tempDirectoryInputVariableName = 'Agent.TempDirectory';
+
+// Output variables.
+export const editorLogFilePathOutputVariableName = 'editorLogFilePath';
 
 function run() {
     try {
@@ -47,12 +49,12 @@ function run() {
             unityVersion = getUnityEditorVersion();
         }
 
-        const unityExecutablePath = UnityPathTools.getUnityExecutableFullPath(unityEditorsPath, unityVersion.info!);
-        const logFilesDirectory = path.join(tl.getVariable(tempDirectoryInputVariableName)!, 'Logs');
-        const logFilePath = path.join(logFilesDirectory, `UnityActivationLog_${Utilities.getLogFileNameTimeStamp()}.log`);
-
         // Set output variable values.
-        tl.setVariable('logsOutputPath', logFilesDirectory);
+        const logFilesDirectory = path.join(tl.getVariable('Agent.TempDirectory')!, 'Logs');
+        const logFilePath = path.join(logFilesDirectory, `UnityActivationLog_${Utilities.getLogFileNameTimeStamp()}.log`);
+        tl.setVariable(editorLogFilePathOutputVariableName, logFilePath);
+
+        const unityExecutablePath = UnityPathTools.getUnityExecutableFullPath(unityEditorsPath, unityVersion.info!);
 
         // Execute Unity command line.
         const unityCmd = tl.tool(unityExecutablePath)

--- a/Tasks/UnityTest/UnityTestV1/CHANGELOG.md
+++ b/Tasks/UnityTest/UnityTestV1/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3]
+
+### Changed
+
+- The output variable `editorLogFilePath` now points directly to the genereated lot file instead of the folder containing it. This is to avoid uploading log files from previous runs if there happen to be multiple log files in the log directory
+
 ## [1.5.2]
 
 ### Fixed

--- a/Tasks/UnityTest/UnityTestV1/package.json
+++ b/Tasks/UnityTest/UnityTestV1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dinomite-studios/unity-test-task",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "An Azure Pipelines task to test a Unity project and produce the results in NUnit compatible files.",
   "main": "unity-test.js",
   "scripts": {

--- a/Tasks/UnityTest/UnityTestV1/task.json
+++ b/Tasks/UnityTest/UnityTestV1/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 5,
-    "Patch": 2
+    "Patch": 3
   },
   "releaseNotes": "[Full Changelog](https://github.com/Dinomite-Studios/unity-azure-pipelines-tasks/blob/master/Tasks/UnityTest/UnityTestV1/CHANGELOG.md)",
   "minimumAgentVersion": "2.144.0",
@@ -150,8 +150,8 @@
       "description": "Path and FileName of the results in XML format. Path is relative to repository root."
     },
     {
-      "name": "logsOutputPath",
-      "description": "Path to the Unity editor log files generated."
+      "name": "editorLogFilePath",
+      "description": "Specifies the location of the editor log file generated."
     },
     {
       "name": "testsFailed",

--- a/Tasks/UnityTest/UnityTestV1/unity-test.ts
+++ b/Tasks/UnityTest/UnityTestV1/unity-test.ts
@@ -26,7 +26,6 @@ const batchModeInputVariableName = 'batchMode';
 const acceptApiUpdateInputVariableName = 'acceptApiUpdate';
 const noPackageManagerInputVariableName = 'noPackageManager';
 const testResultsPathInputVariableName = 'testResultsPath';
-const tempDirectoryInputVariableName = 'Agent.TempDirectory';
 const cleanBuildInputVariableName = 'Build.Repository.Clean';
 const additionalCmdArgsInputVariableName = 'additionalCmdArgs';
 
@@ -37,13 +36,10 @@ const testSuccessNoTestsFailed = 0;
 const testSuccessTestsFailed = 2;
 
 // Output variables.
-const logsOutputPathOutputVariableName = 'logsOutputPath';
+const editorLogFilePathOutputVariableName = 'editorLogFilePath';
 const testResultsOutputPathAndFileNameOutputVariableName = 'testResultsOutputPathAndFileName';
 const testsFailedOutputVariableName = 'testsFailed';
 
-/**
- * Main task runner. Executes the task and sets the result status for the task.
- */
 async function run() {
     try {
         // Setup and read inputs.
@@ -65,15 +61,14 @@ async function run() {
         const acceptApiUpdate = tl.getBoolInput(acceptApiUpdateInputVariableName);
         const noPackageManager = tl.getBoolInput(noPackageManagerInputVariableName);
         const additionalCmdArgs = tl.getInput(additionalCmdArgsInputVariableName) ?? '';
-        const repositoryLocalPath = tl.getVariable(tempDirectoryInputVariableName)!;
         const testResultsFileName = testMode === UnityTestMode.editMode ? editModeResultsFileName : playModeResultsFileName;
         const testResultsPathAndFileName = path.join(`${testResultsPath}`, `${testResultsFileName}`);
-        const logFilesDirectory = path.join(repositoryLocalPath, 'Logs');
-        const logFilePath = path.join(logFilesDirectory, `UnityTestLog_${Utilities.getLogFileNameTimeStamp()}.log`);
 
         // Set output variable values.
-        tl.setVariable(logsOutputPathOutputVariableName, logFilesDirectory);
         tl.setVariable(testResultsOutputPathAndFileNameOutputVariableName, testResultsPathAndFileName);
+        const logFilesDirectory = path.join(tl.getVariable('Agent.TempDirectory')!, 'Logs');
+        const logFilePath = path.join(logFilesDirectory, `UnityTestLog_${Utilities.getLogFileNameTimeStamp()}.log`);
+        tl.setVariable(editorLogFilePathOutputVariableName, logFilePath);
 
         // If clean was specified by the user, delete the existing test results, if any exist.
         if (cleanBuild === 'true') {


### PR DESCRIPTION
The former `logsOutputPath` output variable is now called `editorLogFilePath` for all tasks and points directly to the genereated Unity log file as compared to earlier, where it would point to the Logs directory. The previous implementation was error prone as there could be potentially many log files in that directory that are unrelated to the most recent task run.