### PR TITLE
Add a specific version of build scripts

### DIFF
--- a/Tasks/UnityBuild/UnityBuildV3/unity-build.ts
+++ b/Tasks/UnityBuild/UnityBuildV3/unity-build.ts
@@ -105,7 +105,7 @@ async function run() {
         if (buildScriptType === 'default') {
             // When using default build scripts we rely on a Utility package being installed to the project via the Unity Package Manager.
             // By adding it to the manifest before opening the project, Unity will load the package before trying to build the project.
-            UnityPackageManagerTools.addPackageToProject(projectPath, 'games.dinomite.azurepipelines', 'https://github.com/Dinomite-Studios/unity-azure-pipelines-tasks-build-scripts.git');
+            UnityPackageManagerTools.addPackageToProject(projectPath, 'games.dinomite.azurepipelines', 'https://github.com/Dinomite-Studios/games.dinomite.azurepipelines.git#v1.0.13');
             unityCmd.arg('-executeMethod').arg('AzurePipelinesBuild.PerformBuild');
             unityCmd.arg('-outputFileName').arg(outputFileName);
             unityCmd.arg('-outputPath').arg(outputPath);

--- a/Tasks/UnitySetup/UnitySetupV2/unity-editor-configuration.ts
+++ b/Tasks/UnitySetup/UnitySetupV2/unity-editor-configuration.ts
@@ -30,7 +30,7 @@ export class UnityEditorConfiguration {
 
             // Add the build scripts package to the dummy project. It contains the required
             // C# scripts that will make sure to initialize editor Android settings.
-            UnityPackageManagerTools.addPackageToProject(temporaryProjectPath, 'games.dinomite.azurepipelines', 'https://github.com/Dinomite-Studios/unity-azure-pipelines-tasks-build-scripts.git');
+            UnityPackageManagerTools.addPackageToProject(temporaryProjectPath, 'games.dinomite.azurepipelines', 'https://github.com/Dinomite-Studios/games.dinomite.azurepipelines.git#v1.0.13');
             const editorPath = UnityPathTools.getUnityEditorDirectory(editorInstallationsPath, editorVersion!);
 
             const androidJDKPath = path.join(editorPath, 'Data', 'PlaybackEngines', 'AndroidPlayer', 'OpenJDK');


### PR DESCRIPTION
Instead of adding the current main branch state of the build scripts we now add a specific version using a git-Tag. This will prevent faulty versions from being used by build pipelines.

- Fix https://github.com/Dinomite-Studios/unity-azure-pipelines-tasks/issues/277