### PR TITLE
Correcting UnitySetupTask postjobexecution repetition

### DIFF
--- a/Tasks/UnitySetup/UnitySetupV2/task.json
+++ b/Tasks/UnitySetup/UnitySetupV2/task.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "unityInstallation",
-      "displayName": "Unity Installation / Configuraiton",
+      "displayName": "Unity Installation / Configuration",
       "isExpanded": true
     },
     {

--- a/Tasks/UnitySetup/UnitySetupV2/unity-editor-activation.ts
+++ b/Tasks/UnitySetup/UnitySetupV2/unity-editor-activation.ts
@@ -1,5 +1,5 @@
 import tl = require('azure-pipelines-task-lib/task');
-import { usernameInputVariableName, passwordInputVariableName, serialInputVariableName, activateLicenseInputVariableName } from './unity-setup';
+import { usernameInputVariableName, passwordInputVariableName, serialInputVariableName, activateLicenseInputVariableName } from './variables';
 import { getProjectUnityVersion } from './utilities';
 import path = require('path');
 import { UnityPathTools, Utilities } from '@dinomite-studios/unity-azure-pipelines-tasks-lib';

--- a/Tasks/UnitySetup/UnitySetupV2/unity-editor-configuration.ts
+++ b/Tasks/UnitySetup/UnitySetupV2/unity-editor-configuration.ts
@@ -1,7 +1,7 @@
 import { UnityPathTools, UnityPackageManagerTools } from '@dinomite-studios/unity-azure-pipelines-tasks-lib';
 import tl = require('azure-pipelines-task-lib/task');
 import path = require('path');
-import { androidChildModulesInputVariableName, androidConfigureToolingInputVariableName, androidModuleInputVariableName } from './unity-setup';
+import { androidChildModulesInputVariableName, androidConfigureToolingInputVariableName, androidModuleInputVariableName } from './variables';
 import { getProjectUnityVersion } from './utilities';
 
 export class UnityEditorConfiguration {

--- a/Tasks/UnitySetup/UnitySetupV2/unity-editor-deactivation.ts
+++ b/Tasks/UnitySetup/UnitySetupV2/unity-editor-deactivation.ts
@@ -1,5 +1,5 @@
 import tl = require('azure-pipelines-task-lib/task');
-import { usernameInputVariableName, passwordInputVariableName, serialInputVariableName, deactivateSeatOnCompleteInputVariableName, activateLicenseInputVariableName } from './unity-setup';
+import { usernameInputVariableName, passwordInputVariableName, serialInputVariableName, deactivateSeatOnCompleteInputVariableName, activateLicenseInputVariableName } from './variables';
 import { getProjectUnityVersion } from './utilities';
 import path = require('path');
 import { UnityPathTools, Utilities } from '@dinomite-studios/unity-azure-pipelines-tasks-lib';

--- a/Tasks/UnitySetup/UnitySetupV2/unity-editor-deactivation.ts
+++ b/Tasks/UnitySetup/UnitySetupV2/unity-editor-deactivation.ts
@@ -11,6 +11,11 @@ export class UnityEditorDeactivation {
             return 0;
         }
 
+	const deactivateSeatOnComplete = tl.getBoolInput(deactivateSeatOnCompleteInputVariableName);
+	if (!deactivateSeatOnComplete) {
+	    return 0;
+	}
+
         const editorVersion = getProjectUnityVersion();
         const editorInstallationsPath = UnityPathTools.getUnityEditorsPath('default');
         const unityExecutablePath = UnityPathTools.getUnityExecutableFullPath(editorInstallationsPath, editorVersion!);
@@ -19,25 +24,23 @@ export class UnityEditorDeactivation {
         const password = tl.getInput(passwordInputVariableName, true)!;
 
         const logFilesDirectory = path.join(tl.getVariable('Agent.TempDirectory')!, 'Logs');
-        const logFilePath = path.join(logFilesDirectory, `UnityDeactivationLog_${Utilities.getLogFileNameTimeStamp()}.log`);
-        const deactivateSeatOnComplete = tl.getBoolInput(deactivateSeatOnCompleteInputVariableName);
+        const logFilePath = path.join(logFilesDirectory, `UnityDeactivationLog_${Utilities.getLogFileNameTimeStamp()}.log`);        
 
-        if (deactivateSeatOnComplete) {
-            const unityCmd = tl.tool(unityExecutablePath)
-                .arg('-batchmode')
-                .arg('-nographics')
-                .arg('-username').arg(username)
-                .arg('-password').arg(password)
-                .arg('-returnlicense')
-                .arg('-logfile').arg(logFilePath)
-                .arg('-quit');
 
-            const result = unityCmd.execSync();
+        const unityCmd = tl.tool(unityExecutablePath)
+            .arg('-batchmode')
+            .arg('-nographics')
+            .arg('-username').arg(username)
+            .arg('-password').arg(password)
+            .arg('-returnlicense')
+            .arg('-logfile').arg(logFilePath)
+            .arg('-quit');
 
-            if (result.code !== 0) {
-                return result.code;
-            }
-        }
+        const result = unityCmd.execSync();
+
+        if (result.code !== 0) {
+            return result.code;
+        }       
 
         return 0;
     }

--- a/Tasks/UnitySetup/UnitySetupV2/unity-editor-install.ts
+++ b/Tasks/UnitySetup/UnitySetupV2/unity-editor-install.ts
@@ -2,7 +2,7 @@ import tl = require('azure-pipelines-task-lib/task');
 import path = require('path');
 import { OS, Utilities } from '@dinomite-studios/unity-azure-pipelines-tasks-lib/';
 import { getProjectUnityVersion, getUnityHubExecutablePath } from './utilities';
-import { macOSArchitectureVariableName } from './unity-setup';
+import { macOSArchitectureVariableName, installEditorInputVariableName } from './variables';
 
 export class UnityEditorInstall {
     public static run(): number {

--- a/Tasks/UnitySetup/UnitySetupV2/unity-editor-install.ts
+++ b/Tasks/UnitySetup/UnitySetupV2/unity-editor-install.ts
@@ -6,6 +6,11 @@ import { macOSArchitectureVariableName, installEditorInputVariableName } from '.
 
 export class UnityEditorInstall {
     public static run(): number {
+	const installEditor = tl.getBoolInput(installEditorInputVariableName);
+        if (!installEditor) {
+            return 0;
+        }
+
         const unityHubExecutablePath = getUnityHubExecutablePath();
         const editorVersion = getProjectUnityVersion();
 

--- a/Tasks/UnitySetup/UnitySetupV2/unity-modules-install.ts
+++ b/Tasks/UnitySetup/UnitySetupV2/unity-modules-install.ts
@@ -5,6 +5,11 @@ import { getProjectUnityVersion, getUnityHubExecutablePath } from "./utilities";
 export class UnityModulesInstall {
 
     public static run(): number {
+        const installEditor = tl.getBoolInput(installEditorInputVariableName);
+        if (!installEditor) {
+            return 0;
+        }
+
         const unityHubExecutablePath = getUnityHubExecutablePath();
         const editorVersion = getProjectUnityVersion();
 

--- a/Tasks/UnitySetup/UnitySetupV2/unity-modules-install.ts
+++ b/Tasks/UnitySetup/UnitySetupV2/unity-modules-install.ts
@@ -1,4 +1,4 @@
-import { androidChildModulesInputVariableName, androidModuleInputVariableName, iOSModuleInputVariableName, linuxIL2CPPModuleInputVariableName, linuxMonoModuleInputVariableName, macIL2CPPModuleInputVariableName, macMonoModuleInputVariableName, tvOSModuleInputVariableName, uwpModuleInputVariableName, visionOSModuleInputVariableName, webGLModuleInputVariableName, windowsModuleInputVariableName } from "./unity-setup";
+import { installEditorInputVariableName, androidChildModulesInputVariableName, androidModuleInputVariableName, iOSModuleInputVariableName, linuxIL2CPPModuleInputVariableName, linuxMonoModuleInputVariableName, macIL2CPPModuleInputVariableName, macMonoModuleInputVariableName, tvOSModuleInputVariableName, uwpModuleInputVariableName, visionOSModuleInputVariableName, webGLModuleInputVariableName, windowsModuleInputVariableName } from "./variables";
 import tl = require('azure-pipelines-task-lib/task');
 import { getProjectUnityVersion, getUnityHubExecutablePath } from "./utilities";
 

--- a/Tasks/UnitySetup/UnitySetupV2/unity-setup.ts
+++ b/Tasks/UnitySetup/UnitySetupV2/unity-setup.ts
@@ -5,32 +5,6 @@ import { UnityModulesInstall } from './unity-modules-install';
 // import { UnityEditorConfiguration } from './unity-editor-configuration';
 import { UnityEditorActivation } from './unity-editor-activation';
 
-// Input variables
-export const versionSelectionModeVariableName = "versionSelectionMode";
-export const versionInputVariableName = 'version';
-export const revisionInputVariableName = 'revision';
-export const activateLicenseInputVariableName = 'activateLicense';
-export const usernameInputVariableName = 'username';
-export const passwordInputVariableName = 'password';
-export const serialInputVariableName = 'serial';
-export const deactivateSeatOnCompleteInputVariableName = 'deactivateSeatOnComplete';
-export const unityHubExecutableLocationVariableName = 'unityHubExecutableLocation';
-export const customUnityHubExecutableLocationVariableName = 'customUnityHubExecutableLocation';
-export const macOSArchitectureVariableName = 'macOSArchitecture';
-export const androidModuleInputVariableName = 'installAndroidModule';
-export const androidChildModulesInputVariableName = 'installAndroidChildModules';
-export const androidConfigureToolingInputVariableName = 'configureAndroidTooling';
-export const iOSModuleInputVariableName = 'installIOSModule';
-export const tvOSModuleInputVariableName = 'installTVOSModule';
-export const visionOSModuleInputVariableName = 'installVisionOSModule';
-export const linuxMonoModuleInputVariableName = 'installLinuxMonoModule';
-export const linuxIL2CPPModuleInputVariableName = 'installLinuxIL2CPPModule';
-export const macMonoModuleInputVariableName = 'installMacMonoModule';
-export const macIL2CPPModuleInputVariableName = 'installMacIL2CPPModule';
-export const windowsModuleInputVariableName = 'installWindowsIL2CPPModule';
-export const uwpModuleInputVariableName = 'installUWPModule';
-export const webGLModuleInputVariableName = 'installWebGLModule';
-
 function run() {
     try {
         // Configure localization.

--- a/Tasks/UnitySetup/UnitySetupV2/utilities.ts
+++ b/Tasks/UnitySetup/UnitySetupV2/utilities.ts
@@ -1,6 +1,6 @@
 import tl = require('azure-pipelines-task-lib/task');
 import { UnityPathTools, UnityVersionInfo, UnityVersionInfoResult, UnityVersionTools } from '@dinomite-studios/unity-azure-pipelines-tasks-lib/';
-import { customUnityHubExecutableLocationVariableName, revisionInputVariableName, unityHubExecutableLocationVariableName, versionInputVariableName, versionSelectionModeVariableName } from './unity-setup';
+import { customUnityHubExecutableLocationVariableName, revisionInputVariableName, unityHubExecutableLocationVariableName, versionInputVariableName, versionSelectionModeVariableName } from './variables';
 
 export function getProjectUnityVersion(): UnityVersionInfo | null | undefined {
     let editorVersion: UnityVersionInfo | null | undefined;

--- a/Tasks/UnitySetup/UnitySetupV2/variables.ts
+++ b/Tasks/UnitySetup/UnitySetupV2/variables.ts
@@ -1,0 +1,28 @@
+import tl = require('azure-pipelines-task-lib/task');
+
+// Input variables
+export const versionSelectionModeVariableName = "versionSelectionMode";
+export const versionInputVariableName = 'version';
+export const revisionInputVariableName = 'revision';
+export const activateLicenseInputVariableName = 'activateLicense';
+export const installEditorInputVariableName = 'installEditor';
+export const usernameInputVariableName = 'username';
+export const passwordInputVariableName = 'password';
+export const serialInputVariableName = 'serial';
+export const deactivateSeatOnCompleteInputVariableName = 'deactivateSeatOnComplete';
+export const unityHubExecutableLocationVariableName = 'unityHubExecutableLocation';
+export const customUnityHubExecutableLocationVariableName = 'customUnityHubExecutableLocation';
+export const macOSArchitectureVariableName = 'macOSArchitecture';
+export const androidModuleInputVariableName = 'installAndroidModule';
+export const androidChildModulesInputVariableName = 'installAndroidChildModules';
+export const androidConfigureToolingInputVariableName = 'configureAndroidTooling';
+export const iOSModuleInputVariableName = 'installIOSModule';
+export const tvOSModuleInputVariableName = 'installTVOSModule';
+export const visionOSModuleInputVariableName = 'installVisionOSModule';
+export const linuxMonoModuleInputVariableName = 'installLinuxMonoModule';
+export const linuxIL2CPPModuleInputVariableName = 'installLinuxIL2CPPModule';
+export const macMonoModuleInputVariableName = 'installMacMonoModule';
+export const macIL2CPPModuleInputVariableName = 'installMacIL2CPPModule';
+export const windowsModuleInputVariableName = 'installWindowsIL2CPPModule';
+export const uwpModuleInputVariableName = 'installUWPModule';
+export const webGLModuleInputVariableName = 'installWebGLModule';


### PR DESCRIPTION
Heya, I've been using this tool since end of last year, and while it works well in general, I found some small issues that don't necessarily hinder it's function, but fixing them was a small QoL improvement for me.

The biggest one was the UnitySetupTask post-job, which kept trying to repeat the whole setup task, which costs time and sometimes caused the pipeline to fail at the end, since I didn't expect it to repeat.
My solution was moving the shared variables to their own file so the main unity-setup function wouldn't get called when other scripts are just looking for the variables.
While poking around in the code I noticed that the "installEditor" bool is actually not being used, I implemented it in the "unity-_-install" scripts.
I also moved the "deactivateSeatOnComplete" bool in "unity-editor-deactivation" to the start of the code like it is in the other functions.

I commented each commit for more details, hope it's not too much at once :)