### PR TITLE
Add `scriptCompletionQuit` option

### DIFF
--- a/Tasks/UnityBuild/UnityBuildV3/task.json
+++ b/Tasks/UnityBuild/UnityBuildV3/task.json
@@ -201,6 +201,16 @@
       "helpMarkDown": "Specify class and method name of the method to execute in your build script separated by a dot. E.g. `MyClass.PerformBuild`"
     },
     {
+      "name": "scriptCompletionQuit",
+      "type": "boolean",
+      "label": "Quit after script method completion",
+      "groupName": "build",
+      "visibleRule": "buildScriptType = existing",
+      "required": false,
+      "defaultValue": true,
+      "helpMarkDown": "Weather to quit the Unity editor after the build script method has completed. If set to false, the editor will stay open after the build script method has completed. The default value is true."
+    },
+    {
       "name": "additionalCmdArgs",
       "type": "string",
       "label": "Command line arguments",

--- a/Tasks/UnityBuild/UnityBuildV3/unity-build.ts
+++ b/Tasks/UnityBuild/UnityBuildV3/unity-build.ts
@@ -20,6 +20,7 @@ const buildScriptTypeInputVariableName = 'buildScriptType';
 const unityEditorsPathModeInputVariableName = 'unityEditorsPathMode';
 const inlineBuildScriptInputVariableName = 'inlineBuildScript';
 const scriptExecuteMethodInputVariableName = 'scriptExecuteMethod';
+const scriptCompletionQuitInputVariableName = 'scriptCompletionQuit';
 const additionalCmdArgsInputVariableName = 'additionalCmdArgs';
 const customUnityEditorsPathInputVariableName = 'customUnityEditorsPath';
 const cleanBuildInputVariableName = 'Build.Repository.Clean';
@@ -138,7 +139,11 @@ async function run() {
             unityCmd.arg('-executeMethod').arg(tl.getInput(scriptExecuteMethodInputVariableName)!);
         } else if (buildScriptType === 'existing') {
             // If the user already has an existing build script we only need the method to execute.
-            unityCmd.arg('-executeMethod').arg(tl.getInput(scriptExecuteMethodInputVariableName)!).arg('-quit');
+            unityCmd.arg('-executeMethod').arg(tl.getInput(scriptExecuteMethodInputVariableName)!);
+
+            if (tl.getBoolInput(scriptCompletionQuitInputVariableName)) {
+                unityCmd.arg('-quit');
+            }
         } else {
             throw `Unsupported build script type ${buildScriptType}`
         }


### PR DESCRIPTION
Fix #290

### Problem

Hey, I've been using this script in a professionnal environment, and stumbled accross this weird case where, basically, I have to make an asyncronous task to wait for Unity to finish some background stuff.

The problem is that when `buildScriptType` is set to `existing`, the `-quit` argument is appened to the Unity command, making Unity close before my method is *actually* completed.

### Solution

This PR adds an `scriptCompletionQuit` option, that is totally optionnal, and defaults to the actual behavior (which is, automatically quit after the method is completed).

People that wants to do more stuff with their method can set it to `false`, and are responsible for closing Unity from the desired location, at the desired time.